### PR TITLE
fix-resetGame

### DIFF
--- a/HK/prototype_back_test.js
+++ b/HK/prototype_back_test.js
@@ -774,6 +774,12 @@ function resetGame() {
 
     character.position.set(4, 1.5, 0);
     velocity.set(0.03, 0, 0);
+
+    Object.keys(keys).forEach(key => {
+        keys[key] = false;
+    });
+    character.rotation.y = Math.PI/2 
+
 }
 
 init();

--- a/src/prototype_back.js
+++ b/src/prototype_back.js
@@ -765,6 +765,13 @@ function resetGame() {
 
     character.position.set(4, 1.5, 0);
     velocity.set(0.03, 0, 0);
+    
+    //이동키 초기화, 캐릭터 방향 초기화
+    Object.keys(keys).forEach(key => { 
+        keys[key] = false;
+    });
+    character.rotation.y = Math.PI/2
+
 }
 
 init();


### PR DESCRIPTION
게임 오버 후, 재시작하였을 때, 이동키가 눌린 상태가 유지되던 버그를 수정하였습니다.
캐릭터가 재시작하였을 때, 정면을 보도록 수정했습니다.